### PR TITLE
Update theme colors to black and red

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,3 +1,32 @@
+/* Bootstrap overrides to switch the palette to the new black and red theme. */
+:root {
+    --primary-red: #c1121f;
+    --primary-red-rgb: 193, 18, 31;
+    --deep-black: #050505;
+    --soft-black: #121212;
+    --surface-black: #1a1a1a;
+    --text-light: #f5f5f5;
+    --bs-body-bg: var(--deep-black);
+    --bs-body-color: var(--text-light);
+    --bs-primary: var(--primary-red);
+    --bs-primary-rgb: 193, 18, 31;
+    --bs-secondary: #660708;
+    --bs-secondary-rgb: 102, 7, 8;
+    --bs-dark: #000000;
+    --bs-dark-rgb: 0, 0, 0;
+    --bs-light: var(--surface-black);
+    --bs-light-rgb: 26, 26, 26;
+    --bs-secondary-color: #c9c9c9;
+    --bs-link-color: var(--primary-red);
+    --bs-link-hover-color: #ff4d5a;
+    --bs-border-color: #2a2a2a;
+}
+
+body {
+    background-color: var(--bs-body-bg);
+    color: var(--bs-body-color);
+}
+
 /* obrázek na pozadí v jumbotronu */
 #vedeni-ucetnictvi {
     background-image: url("./assets/images/matous-burysek-ucetnictvi-Brno.jpeg");
@@ -34,31 +63,26 @@ h5 {
     margin: 0px auto 0px auto;
     border-radius: 3px;
     padding: 2px 8px;
-    background-color:hsl(220, 90%, 56%);
-    color: white;
+    background-color: rgba(193, 18, 31, 0.85);
+    color: var(--text-light);
 }
 
 /* změna stylu odkazů */
 
 a {
-    color: unset;
-    text-decoration: none; 
+    color: var(--bs-link-color);
+    text-decoration: none;
 }
 
 a:hover {
-    font-weight: bolder; 
-    color: hsl(220, 90%, 56%);
-}
-
-/* stejná výška všech karet článk */
-.card {
-    min-height: 450px;
+    font-weight: bolder;
+    color: var(--bs-link-hover-color);
 }
 
 /* šedé pohybující se pozadí v některých sekcích */
 
 #matous-burysek, #ucetni-software, #clanek, #kontakt {
-    background-image: url("/assets/images/grey-bg.jpg");
+    background-image: linear-gradient(rgba(0, 0, 0, 0.8), rgba(193, 18, 31, 0.35)), url("/assets/images/grey-bg.jpg");
     background-position: center;
     background-repeat: no-repeat;
     background-size: cover;
@@ -70,6 +94,17 @@ table, td {
     padding-left: 0px !important;
     border-left: 0px;
     border: none;
+    color: var(--text-light);
+}
+
+.table {
+    --bs-table-bg: transparent;
+    --bs-table-striped-bg: rgba(193, 18, 31, 0.15);
+    --bs-table-striped-color: var(--text-light);
+    --bs-table-hover-bg: rgba(193, 18, 31, 0.25);
+    --bs-table-hover-color: var(--text-light);
+    color: var(--text-light);
+    border-color: rgba(193, 18, 31, 0.4);
 }
 
 /* kontaktní okno - nevyužívá Bootstrap */
@@ -80,10 +115,10 @@ table, td {
     top: 15%;
     left: 20%;
     width: 60%;
-    background-color: hsl(220, 90%, 56%);
+    background-color: rgba(193, 18, 31, 0.95);
     border-radius: 15px;
-    box-shadow: 0 0 10px black;
-    color: white;
+    box-shadow: 0 0 25px rgba(0, 0, 0, 0.65);
+    color: var(--text-light);
 }
 
 #close-button {
@@ -91,13 +126,13 @@ table, td {
     top: 5px;
     right: 15px;
     font-size: xx-large;
-    color: black;
+    color: var(--deep-black);
     /* font-weight: bold; */
     cursor: pointer;
 }
 
 #close-button:hover {
-    color: white;
+    color: var(--text-light);
     font-weight: bold;
 }
 
@@ -110,9 +145,128 @@ table, td {
         left: auto;
         right: auto;
         width: 90%;
-        background-color: hsl(220, 90%, 56%);
+        background-color: rgba(193, 18, 31, 0.95);
         border-radius: 15px;
-        box-shadow: 0 0 10px black;
-        color: white;
+        box-shadow: 0 0 25px rgba(0, 0, 0, 0.65);
+        color: var(--text-light);
     }
+}
+
+/* zvýraznění sekcí pro černou/červenou paletu */
+
+#sluzby {
+    background-color: var(--surface-black);
+}
+
+#poptavka {
+    background-color: var(--primary-red);
+    color: var(--text-light);
+}
+
+#poptavka .btn-primary {
+    background-color: var(--deep-black);
+    border-color: var(--deep-black);
+    color: var(--text-light);
+}
+
+#poptavka .btn-primary:hover {
+    background-color: var(--soft-black);
+    border-color: var(--soft-black);
+}
+
+#ucetni-software,
+#kontaktni-formular,
+#dalsi-clanky {
+    background-color: var(--surface-black);
+}
+
+#dalsi-clanky {
+    background-color: var(--primary-red);
+}
+
+#kontaktni-formular {
+    background: linear-gradient(135deg, rgba(0, 0, 0, 0.9), rgba(193, 18, 31, 0.85));
+    border: 1px solid rgba(193, 18, 31, 0.5);
+    color: var(--text-light);
+}
+
+footer {
+    background-color: #000000;
+}
+
+.card {
+    min-height: 450px;
+    background-color: var(--soft-black);
+    color: var(--text-light);
+    border: 1px solid rgba(193, 18, 31, 0.4);
+}
+
+.card .card-title,
+.card .card-text,
+.card .text-muted {
+    color: inherit;
+}
+
+.card .text-muted {
+    color: #bbbbbb !important;
+}
+
+.card .btn-primary {
+    background-color: var(--primary-red);
+    border-color: var(--primary-red);
+}
+
+.card .btn-primary:hover {
+    background-color: #a70e1a;
+    border-color: #a70e1a;
+}
+
+.form-control,
+.form-select,
+.form-control:focus,
+.form-select:focus {
+    background-color: var(--surface-black);
+    color: var(--text-light);
+    border-color: rgba(193, 18, 31, 0.65);
+}
+
+.form-control::placeholder,
+.form-select::placeholder {
+    color: #bbbbbb;
+}
+
+.form-control:focus,
+.form-select:focus {
+    box-shadow: 0 0 0 0.25rem rgba(193, 18, 31, 0.35);
+}
+
+.form-check-input {
+    background-color: var(--soft-black);
+    border-color: rgba(193, 18, 31, 0.65);
+}
+
+.form-check-input:checked {
+    background-color: var(--primary-red);
+    border-color: var(--primary-red);
+}
+
+.btn-dark,
+.text-bg-dark {
+    background-color: #000000 !important;
+    border-color: #000000 !important;
+}
+
+.btn-dark:hover {
+    background-color: #1a1a1a !important;
+    border-color: #1a1a1a !important;
+}
+
+.btn-outline-light {
+    color: var(--text-light);
+    border-color: var(--text-light);
+}
+
+.btn-outline-light:hover {
+    color: var(--deep-black);
+    background-color: var(--text-light);
 }


### PR DESCRIPTION
## Summary
- override Bootstrap theme variables to introduce a black background with red accents
- restyle sections, buttons, cards, and forms so the UI consistently uses the black and red palette
- refresh gradients and overlays to keep imagery legible against the darker theme

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cfe6f139a8832c8fc1e18676e0c9dd